### PR TITLE
add __all__ to satisfy typecheckers

### DIFF
--- a/deepdiff/__init__.py
+++ b/deepdiff/__init__.py
@@ -12,3 +12,5 @@ from .search import DeepSearch, grep
 from .deephash import DeepHash
 from .delta import Delta
 from .path import extract, parse_path
+
+__all__ = ["DeepDiff", "DeepSearch", "grep", "DeepHash", "Delta", "extract", "parse_path"]


### PR DESCRIPTION
pyright is unhappy when you import from the root package like `from deepdiff import DeepDiff`, it complains that the class is not explicitly exported.

![CleanShot 2025-02-20 at 22 06 35](https://github.com/user-attachments/assets/98c3a591-f5a6-41c5-ba39-1f0d5c2689c1)
